### PR TITLE
Refactor Portal API

### DIFF
--- a/nxrm_two_portal/src/auth.rs
+++ b/nxrm_two_portal/src/auth.rs
@@ -6,12 +6,13 @@ use axum::{
 };
 use base64::prelude::{Engine, BASE64_STANDARD};
 use eyre::{bail, OptionExt};
+use portal_api::Credentials;
 use tracing::instrument;
 
 #[derive(Clone)]
 pub struct UserToken {
     pub token_username: String,
-    pub token_password: String,
+    token_password: String,
 }
 
 impl UserToken {
@@ -28,8 +29,8 @@ impl UserToken {
         })
     }
 
-    pub fn as_token(&self) -> String {
-        BASE64_STANDARD.encode(format!("{}:{}", self.token_username, self.token_password))
+    pub fn as_credentials(self) -> Credentials {
+        Credentials::new(self.token_username, self.token_password)
     }
 }
 

--- a/nxrm_two_portal/src/main.rs
+++ b/nxrm_two_portal/src/main.rs
@@ -4,6 +4,7 @@ use axum::{
     routing::{get, post, put},
     Router,
 };
+use portal_api::PortalApiClient;
 use tokio::net::TcpListener;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
@@ -33,7 +34,10 @@ async fn main() -> eyre::Result<()> {
         .with(EnvFilter::from_default_env())
         .init();
 
-    let app_state = AppState::new(LocalRepository::new()?);
+    let local_repository = LocalRepository::new()?;
+    let portal_api_client = PortalApiClient::client("https://staging.portal.central.sonatype.dev")?;
+
+    let app_state = AppState::new(local_repository, portal_api_client);
 
     let staging_endpoints = Router::new()
         .route("/profile_evaluate", get(staging_profile_evaluate_endpoint))

--- a/nxrm_two_portal/src/state.rs
+++ b/nxrm_two_portal/src/state.rs
@@ -1,15 +1,18 @@
 use std::sync::Arc;
 
+use portal_api::PortalApiClient;
 use repository::traits::Repository;
 
 pub struct AppState<R: Repository> {
     pub repository: Arc<R>,
+    pub portal_api_client: Arc<PortalApiClient>,
 }
 
 impl<R: Repository> AppState<R> {
-    pub fn new(repository: R) -> Self {
+    pub fn new(repository: R, portal_api_client: PortalApiClient) -> Self {
         Self {
             repository: Arc::new(repository),
+            portal_api_client: Arc::new(portal_api_client),
         }
     }
 }
@@ -18,6 +21,7 @@ impl<R: Repository> Clone for AppState<R> {
     fn clone(&self) -> Self {
         Self {
             repository: self.repository.clone(),
+            portal_api_client: self.portal_api_client.clone(),
         }
     }
 }

--- a/portal_api/examples/upload.rs
+++ b/portal_api/examples/upload.rs
@@ -46,12 +46,17 @@ pub async fn main() -> eyre::Result<()> {
 
     let credentials = Credentials::new(username, password);
 
-    let mut api_client = PortalApiClient::client(&host, credentials)?;
+    let mut api_client = PortalApiClient::client(&host)?;
 
     let deployment_name = cli.deployment_name.unwrap_or("Upload".to_string());
 
     let deployment_id = api_client
-        .upload_from_file(&deployment_name, Automatic, &cli.upload_bundle)
+        .upload_from_file(
+            &credentials,
+            &deployment_name,
+            Automatic,
+            &cli.upload_bundle,
+        )
         .await?;
 
     println!("Deployment ID: {deployment_id}");

--- a/portal_api/src/credentials.rs
+++ b/portal_api/src/credentials.rs
@@ -1,6 +1,9 @@
 use base64::engine::general_purpose::STANDARD;
 use base64::engine::Engine;
-use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
+use reqwest::{
+    header::{HeaderValue, AUTHORIZATION},
+    RequestBuilder,
+};
 
 pub struct Credentials {
     username: String,
@@ -12,11 +15,14 @@ impl Credentials {
         Self { username, password }
     }
 
-    pub fn add_credentials_to_headers(&self, headers: &mut HeaderMap) -> eyre::Result<()> {
+    pub fn add_credentials_to_request(
+        &self,
+        request: RequestBuilder,
+    ) -> eyre::Result<RequestBuilder> {
         let token_header = HeaderValue::from_str(&self.as_bearer_token())?;
-        headers.insert(AUTHORIZATION, token_header);
+        let request = request.header(AUTHORIZATION, token_header);
         tracing::trace!("Added {AUTHORIZATION} header");
-        Ok(())
+        Ok(request)
     }
 
     fn as_bearer_token(&self) -> String {


### PR DESCRIPTION
- Credentials are now passed in per method call (allows the client to be shared across users' requests)
- Create Credentials directly from a UserToken
- Add the client to the state (first step to making the endpoint configurable)